### PR TITLE
typo sv_body = .sv_body

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -52,7 +52,7 @@
 .sv_main {
     width: 100%;
 }
-sv_body {
+.sv_body {
     margin-bottom: 10px;
 }
 .sv_title {


### PR DESCRIPTION
missing period in class sv_body identifier; leads to tight survey spacing in bootstrap containers